### PR TITLE
Fixing issue with multiple triggers at the same time

### DIFF
--- a/automation_reset_power_sensors.yaml
+++ b/automation_reset_power_sensors.yaml
@@ -118,4 +118,4 @@ action:
               qos: "0"
               topic: <appKey>/<deviceID>/state
               payload: "{\"solarPower2\":0}"
-mode: single
+mode: parallel


### PR DESCRIPTION
This commit resolves the issue, that an action is not running, due to 2 actions are triggered at the same time. In "single" mode, the second trigger (in my case often the "packinputpower") is blocked by home assistant. This results, that the value was not changed and stays over a long term (mostly the complete night). In "parallel" mode, both actions will be executed.